### PR TITLE
Registered callables update triggered

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,4 +42,4 @@ repos:
     rev: 85b2c350c6702296f95aa71b8223df644226863d
     hooks:
       - id: pycln
-        args: [--config=pyproject.toml]
+        args: [--config=pyproject.toml, --all]

--- a/asserto/_api.py
+++ b/asserto/_api.py
@@ -5,13 +5,14 @@ from ._asserto import Asserto
 from ._decorators import update_triggered
 
 
-def asserto(actual: typing.Any) -> Asserto:
+def asserto(actual: typing.Any, warn_unused: bool = False) -> Asserto:
     """
     Retrieve an appropriate asserter for the type of value.
     :param actual: The value to compare against later and defer a type specific asserter from.
+    :param warn_unused: Emit a warning if not a single assertion was performed to detect user errors.
     :return: An instance of an asserter
     """
-    return Asserto(actual)
+    return Asserto(actual, warn_unused)
 
 
 def register_assert(

--- a/asserto/_asserto.py
+++ b/asserto/_asserto.py
@@ -29,17 +29,16 @@ class Asserto(AssertoBase):
     """
     The entrypoint into asserting objects.
 
-    :param actual: The actual value
+    :param actual: ...
+    :param warn_unused: ...
     """
 
-    def __init__(
-        self,
-        actual: typing.Any,
-    ):
+    def __init__(self, actual: typing.Any, warn_unused: bool = False):
         self.actual = actual
         self._triggered = False
         self._reason = Reason()
         self._error_handler = ErrorHandler(self._reason)
+        self.warn_unused = warn_unused
 
     def error(self, cause: typing.Union[AssertionError, str]) -> Asserto:
         """
@@ -323,10 +322,6 @@ class Asserto(AssertoBase):
         """
         warnings.warn("Asserto instance was created and never used", NoAssertAttemptedWarning, 2)
 
-    def __del__(self) -> None:
-        if not self.triggered:
-            self._warn_not_triggered()
-
     def __getattr__(self, item: str) -> typing.Callable:
         """
         Adds the capability to object class or instance attributes dynamically.  Supports user defined
@@ -392,7 +387,7 @@ class Asserto(AssertoBase):
         exc_tb: typing.Optional[types.TracebackType] = None,
     ):
         __tracebackhide__ = True
-        if not self.triggered:
+        if self.warn_unused and not self.triggered:
             self._warn_not_triggered()
         if self._error_handler.soft_fails:
             # There was a compilation of assertion errors

--- a/tests/test_asserto.py
+++ b/tests/test_asserto.py
@@ -2,16 +2,12 @@ import pytest
 
 from asserto import NoAssertAttemptedWarning
 
-from .markers import NO_UNTRIGGERED_WARNINGS
 
-
-@NO_UNTRIGGERED_WARNINGS
 def test_simple_repr(asserto) -> None:
     asserto(repr(asserto("foo").set_category("n"))).is_equal_to("Asserto(value=foo, category=n)")
     asserto(repr(asserto(100))).is_equal_to("Asserto(value=100, category=None)")
 
 
-@NO_UNTRIGGERED_WARNINGS
 def test_soft_context_active(asserto) -> None:
     with asserto(1) as soft:
         asserto(soft._error_handler.soft_context).is_true()
@@ -33,17 +29,7 @@ def test_triggered(asserto) -> None:
     asserto(x.triggered).is_true()
 
 
-@NO_UNTRIGGERED_WARNINGS
 def test_context_triggered_warning(asserto) -> None:
     with pytest.warns(NoAssertAttemptedWarning, match="Asserto instance was created and never used"):
-        with asserto(100) as _:
+        with asserto(100, warn_unused=True) as _:
             pass
-
-
-@NO_UNTRIGGERED_WARNINGS
-def test_non_context_triggered_warning(asserto) -> None:
-    with pytest.warns(NoAssertAttemptedWarning, match="Asserto instance was created and never used"):
-        asserto(100)
-
-
-# Test invoking description after triggered raises;

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -3,8 +3,6 @@ import pytest
 from asserto import Asserto
 from asserto import register_assert
 
-from .markers import NO_UNTRIGGERED_WARNINGS
-
 
 def is_length_five(self):
     try:
@@ -30,7 +28,6 @@ def test_binding_successful(asserto) -> None:
     asserto([1, 2, 3, 4, 5]).is_length_five()
 
 
-@NO_UNTRIGGERED_WARNINGS
 def test_calling_unbound(asserto) -> None:
     with pytest.raises(AttributeError) as error:
         asserto(5).is_length_five()

--- a/tests/test_booleans.py
+++ b/tests/test_booleans.py
@@ -15,9 +15,8 @@ def test_bool_not_bool_works_successfully(asserto) -> None:
 
 
 def test_non_false_raises_for_is_false(asserto) -> None:
-    with pytest.raises(AssertionError) as error:
+    with pytest.raises(AssertionError, match=r"True was not False"):
         asserto(True).is_false()
-    asserto(error.value.args[0]).is_equal_to("True was not False")
 
 
 def test_non_true_raises_for_is_true(asserto) -> None:

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -4,7 +4,6 @@ from types import SimpleNamespace
 
 import pytest
 
-from .markers import NO_UNTRIGGERED_WARNINGS
 from .utility.dynamic import Dynamic
 
 
@@ -43,7 +42,6 @@ def test_attr_value_wrong(asserto) -> None:
         asserto(Dynamic(a=9)).a_is(10)
 
 
-@NO_UNTRIGGERED_WARNINGS
 def test_no_attr_raises_attribute_error(asserto) -> None:
     with pytest.raises(AttributeError):
         # dynamic dispatch without ending in `_is`

--- a/tests/test_raising.py
+++ b/tests/test_raising.py
@@ -2,14 +2,11 @@ from __future__ import annotations
 
 import pytest
 
-from .markers import NO_UNTRIGGERED_WARNINGS
-
 
 def test_raises_without_exception(asserto) -> None:
     asserto(_raiser).should_raise(ValueError).when_called_with(x=True)
 
 
-@NO_UNTRIGGERED_WARNINGS
 def test_errors_when_no_exc(asserto) -> None:
     with pytest.raises(
         AssertionError,
@@ -18,7 +15,6 @@ def test_errors_when_no_exc(asserto) -> None:
         asserto(_raiser).should_raise((ValueError, RuntimeError)).when_called_with(x=False)
 
 
-@NO_UNTRIGGERED_WARNINGS
 def test_non_callable_raises_type_error(asserto) -> None:
     with pytest.raises(ValueError, match=r"1 is not callable."):
         asserto(1).should_raise(ValueError).when_called_with(10)

--- a/tests/test_raising.py
+++ b/tests/test_raising.py
@@ -18,9 +18,10 @@ def test_errors_when_no_exc(asserto) -> None:
         asserto(_raiser).should_raise((ValueError, RuntimeError)).when_called_with(x=False)
 
 
+@NO_UNTRIGGERED_WARNINGS
 def test_non_callable_raises_type_error(asserto) -> None:
     with pytest.raises(ValueError, match=r"1 is not callable."):
-        asserto(1).should_raise(Exception).when_called_with(10)
+        asserto(1).should_raise(ValueError).when_called_with(10)
 
 
 def _raiser(x: bool):

--- a/tests/test_reason.py
+++ b/tests/test_reason.py
@@ -2,8 +2,6 @@ import pytest
 
 from asserto._asserto import Reason
 
-from .markers import NO_UNTRIGGERED_WARNINGS
-
 
 @pytest.mark.parametrize(
     "reason_obj, reason_txt, expected",
@@ -22,7 +20,6 @@ def test_described_as(asserto) -> None:
         asserto(1).described_as("foo!").is_equal_to(2)
 
 
-@NO_UNTRIGGERED_WARNINGS
 def test_described_updates_reason(asserto) -> None:
     foo = "foo"
     x = asserto(1).described_as(foo)


### PR DESCRIPTION
 - Registered callables update `triggered`
 - Fix `pycln` for non standard library removal
 - Improve concept of warnings; now `opt in`
 - other test improvements